### PR TITLE
Support for Spotify Authenticated Calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,12 +79,6 @@ musictools.add_metadata(file_name, title, artist, album)
 musictools.revert_metadata(file_name)
 ```
 
-##### Returns specified metadata field for a music file
-
-```
-musictools.get_current_metadata_tag(file_name, tag)
-```
-
 
 ## Example
 ```sh

--- a/README.md
+++ b/README.md
@@ -57,9 +57,9 @@ musictools.get_song_urls(song_name)
 musictools.download_song(song_url, song_title)
 ```
 
-##### Provides artist name, song name, album name and album art for a particular song
+##### Provides artist name, song name, album name and album art for a particular song. Requires Client ID and Client Secret for Spotify API
 ```
-musictools.get_metadata(file_name) 
+musictools.get_metadata(file_name, client_id, client_secret)
 ```
 
 ##### Adds an image as the album art of a mp3 file
@@ -100,7 +100,7 @@ The Beatles - Hey Jude
 >>> musictools.get_metadata(title)
 ('The Beatles', '1 (Remastered)', 'Hey Jude - Remastered 2015', 'https://i.scdn.co/image/9ecfdf528562cae879748b73bd81b64dfa3d5704')
 
->>> artist, album , song_name, albumart = musictools.get_metadata(title)
+>>> artist, album , song_name, albumart = musictools.get_metadata(title, 'YOUR_CLIENT_ID', 'YOUR_CLIENT_SECRET')
 
 >>> musictools.add_albumart(title, albumart)
 >>> musictools.add_metadata(title, song_name, artist, album)

--- a/README.md
+++ b/README.md
@@ -79,6 +79,12 @@ musictools.add_metadata(file_name, title, artist, album)
 musictools.revert_metadata(file_name)
 ```
 
+##### Returns specified metadata field for a music file
+
+```
+musictools.get_current_metadata_tag(file_name, tag)
+```
+
 
 ## Example
 ```sh

--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 [![banner](http://i63.tinypic.com/2qc2dk2.jpg)]()
 
 [![PyPI version](https://badge.fury.io/py/musictools.svg)](https://badge.fury.io/py/musictools)
-[![Build Status](https://travis-ci.org/lakshaykalbhor/MusicTools.svg?branch=master)](https://travis-ci.org/lakshaykalbhor/MusicTools)
+[![Build Status](https://travis-ci.org/kalbhor/MusicTools.svg?branch=master)](https://travis-ci.org/kalbhor/MusicTools)
 
 #### Library to download, sort and tag music files
 
 ## Social
 
-[![GitHub stars](https://img.shields.io/github/stars/lakshaykalbhor/musictools.svg?style=social&label=Star)](https://github.com/lakshaykalbhor/musictools)
-[![GitHub followers](https://img.shields.io/github/followers/lakshaykalbhor.svg?style=social&label=Follow)](https://github.com/lakshaykalbhor)  
+[![GitHub stars](https://img.shields.io/github/stars/kalbhor/musictools.svg?style=social&label=Star)](https://github.com/kalbhor/musictools)
+[![GitHub followers](https://img.shields.io/github/followers/kalbhor.svg?style=social&label=Follow)](https://github.com/kalbhor)  
 [![Twitter Follow](https://img.shields.io/twitter/follow/lakshaykalbhor.svg?style=social)](https://twitter.com/lakshaykalbhor)
 
 
@@ -34,7 +34,7 @@ $ sudo apt-get install libav-tools
 #### From Source:
 
 ```sh
-$ git clone https://github.com/lakshaykalbhor/MusicTools
+$ git clone https://github.com/kalbhor/MusicTools
 $ cd MusicTools
 $ python setup.py install
 ```
@@ -105,16 +105,15 @@ The Beatles - Hey Jude
 >>> musictools.add_albumart(title, albumart)
 >>> musictools.add_metadata(title, song_name, artist, album)
 
-✨
+✨✨VOILA✨✨
 ```
 [![image](image.png)]()
 
 
 
 ## Contributing
-Currently this project is in its infancy and issues are bound to arise.
-To contribute, [post issues](https://github.com/lakshaykalbhor/MusicTools/issues) without hesitation and [open pull requests](https://github.com/lakshaykalbhor/MusicTools/pulls) to add/improve features.
+To contribute, [post issues](https://github.com/kalbhor/MusicTools/issues) without hesitation and [open pull requests](https://github.com/kalbhor/MusicTools/pulls) to add/improve features.
 
 ## License 
-#### [MIT](https://github.com/lakshaykalbhor/MusicTools/blob/master/LICENSE)
+#### [MIT](https://github.com/kalbhor/MusicTools/blob/master/LICENSE)
 

--- a/musictools/musictools.py
+++ b/musictools/musictools.py
@@ -8,6 +8,7 @@ import re
 from mutagen.id3 import ID3, APIC, _util
 from mutagen.mp3 import EasyMP3
 from bs4 import BeautifulSoup
+from spotipy.oauth2 import SpotifyClientCredentials
 
 # Words to omit from song title for better results through spotify's API
 chars_filter = "()[]{}-:_/=+\"\'"
@@ -89,14 +90,15 @@ def download_song(song_url, song_title):
         info_dict = ydl.extract_info(song_url, download=True)
 
 
-def get_metadata(file_name):
+def get_metadata(file_name, client_id, client_secret):
     """
     Tries finding metadata through Spotify
     """
 
     song_name = improve_name(file_name)  # Remove useless words from title
+    client_credentials_manager = SpotifyClientCredentials(client_id, client_secret)
 
-    spotify = spotipy.Spotify()
+    spotify = spotipy.Spotify(client_credentials_manager=client_credentials_manager)
     results = spotify.search(song_name, limit=1)
 
     results = results['tracks']['items'][0]  # Find top result
@@ -106,7 +108,6 @@ def get_metadata(file_name):
     album_art = results['album']['images'][0]['url']
 
     return artist, album, song_title, album_art
-
 
 
 def add_album_art(file_name, album_art):

--- a/musictools/musictools.py
+++ b/musictools/musictools.py
@@ -145,12 +145,22 @@ def add_metadata(file_name, title, artist, album):
     """
     
     tags = EasyMP3(file_name)
-    tags["title"] = title
-    tags["artist"] = artist
-    tags["album"] = album
+    if title: 
+        tags["title"] = title
+    if artist:     
+        tags["artist"] = artist
+    if album:
+        tags["album"] = album
     tags.save()
 
     return file_name
+
+def get_current_metadata_tag(file_name, tag):
+    tags = EasyMP3(file_name)
+    if tag in tags:
+        return tags[tag].pop()
+    else:
+        return "The metadata tag could not be found."
 
 
 def revert_metadata(files):

--- a/musictools/musictools.py
+++ b/musictools/musictools.py
@@ -145,22 +145,12 @@ def add_metadata(file_name, title, artist, album):
     """
     
     tags = EasyMP3(file_name)
-    if title: 
-        tags["title"] = title
-    if artist:     
-        tags["artist"] = artist
-    if album:
-        tags["album"] = album
+    tags["title"] = title
+    tags["artist"] = artist
+    tags["album"] = album
     tags.save()
 
     return file_name
-
-def get_current_metadata_tag(file_name, tag):
-    tags = EasyMP3(file_name)
-    if tag in tags:
-        return tags[tag].pop()
-    else:
-        return "The metadata tag could not be found."
 
 
 def revert_metadata(files):


### PR DESCRIPTION
Manages spotipy's SpotifyClientCredentials object to make authenticated client calls to Spotify's API. get_metadata method now requires client ID and client secret values from Spotify as parameters

Ignore changes 1709c30 & 9ce9534 and their subsequent reverts. Those were changes to another feature I'm working on that I needed to get out of my master before I sent the Pull Request.
